### PR TITLE
Use setImmediate when available instead of process.nextTick

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var traverse = require('traverse');
 var EventEmitter = require('events').EventEmitter;
+var immediate = global.setImmediate || process.nextTick;
 
 module.exports = Chainsaw;
 function Chainsaw (builder) {
@@ -38,7 +39,7 @@ Chainsaw.saw = function (builder, handlers) {
             }
         });
 
-        process.nextTick(function () {
+        immediate(function () {
             saw.emit('begin');
             saw.next();
         });


### PR DESCRIPTION
process.nextTick preempts IO, so in almost all cases setImmediate is preferred.
