### PR TITLE
Correct SPDX identifier for license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
         "monadic"
     ],
     "author" : "James Halliday <mail@substack.net> (http://substack.net)",
-    "license" : "MIT/X11",
+    "license" : "MIT",
     "engine" : { "node" : ">=0.4.0" }
 }


### PR DESCRIPTION
Hi, 
The SPDX ID (cf. https://docs.npmjs.com/files/package.json#license ) is just "MIT" (cf. https://opensource.org/licenses/mit-license.php )
Thanks